### PR TITLE
Improve experience section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -386,7 +386,8 @@ img {
 }
 .experience__container {
   row-gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(1, 1fr);
+  column-gap: 2rem;
 }
 .work__img {
   box-shadow: 0px 4px 25px rgba(14, 36, 49, 0.15);
@@ -417,8 +418,11 @@ img {
   font-weight: var(--font-semi);
 }
 .experience__body {
-  background-color: hsl(var(--hue-color), 100%, 95%);
+  background-color: hsl(var(--hue-color), 100%, 97%);
   padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 240px;
 }
 .experience__course {
   margin: 0 0 0.5rem 0;
@@ -431,6 +435,12 @@ img {
 .experience__description {
   font-size: var(--smaller-font-size);
   margin-bottom: 0.5rem;
+}
+.experience__button {
+  align-self: flex-end;
+  margin-top: auto;
+  padding: 0.25rem 0.75rem;
+  font-size: var(--smaller-font-size);
 }
 
 /* ===== CONTACT =====*/
@@ -578,6 +588,9 @@ img {
     align-items: center;
     text-align: initial;
   }
+  .experience__container {
+    grid-template-columns: repeat(2, 1fr);
+  }
   .work__container {
     grid-template-columns: repeat(3, 1fr);
     column-gap: 2rem;
@@ -593,5 +606,8 @@ img {
   }
   .home__img {
     width: 450px;
+  }
+  .experience__container {
+    grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/hs102.html
+++ b/hs102.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="assets/css/styles.css">
+    <title>HS102: An Intro to Public Health</title>
+</head>
+<body>
+    <header class="l-header">
+        <nav class="nav bd-grid">
+            <div>
+                <a href="index.html" class="nav__logo">Arshdeep</a>
+            </div>
+        </nav>
+    </header>
+
+    <main class="l-main">
+        <section class="section" style="padding-top:6rem;">
+            <h2 class="section-title">HS102: An Intro to Public Health</h2>
+            <h3 class="section-title" style="text-align:left;">Description</h3>
+            <p class="experience__description">Students invent a new disease and, using their knowledge from the course, provide an in-depth profile of this disease, including its impact on the population, relevant disease characteristics, modes of transmission, basic epidemiology and possible public health interventions used to curb this disease.</p>
+            <h3 class="section-title" style="text-align:left;">Developed Competencies</h3>
+            <p class="experience__description">Creativity and Innovation, Communication, Digital Literacy, Problem Solving, Functional Knowledge</p>
+            <h3 class="section-title" style="text-align:left;">Type of Experience</h3>
+            <p class="experience__description">In-course Simulated Experience</p>
+            <h3 class="section-title" style="text-align:left;">What is this experience?</h3>
+            <p class="experience__description">Simulated-workplace projects and experiences completed as a required component of a course or program of study.</p>
+            <h3 class="section-title" style="text-align:left;">What I learned</h3>
+            <p class="experience__description">This project helped me understand how new public health challenges are approached and deepened my appreciation for clear communication when proposing interventions.</p>
+        </section>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
                     <div class="experience__body">
                         <h3 class="experience__course">HS102: An Intro to Public Health</h3>
                         <p class="experience__description">Simulated cases exploring public health principles and interventions.</p>
-                        <a href="#" class="button experience__button">View</a>
+                        <a href="hs102.html" class="button experience__button">View</a>
                     </div>
                 </div>
                 <div class="experience__card">


### PR DESCRIPTION
## Summary
- reduce experience grid to two columns
- shrink and position experience view buttons
- add details page for HS102 experience

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643c3006ec8328891816aa63d6a47a