### PR TITLE
Update modal content and contact form

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -472,6 +472,10 @@ img {
   cursor: pointer;
   margin-left: auto;
 }
+.contact__form {
+  width: 100%;
+  padding-top: 2rem;
+}
 
 /* ===== FOOTER =====*/
 .footer {
@@ -527,6 +531,11 @@ img {
   right: 0.75rem;
   cursor: pointer;
   font-size: 1.5rem;
+  transition: color 0.2s;
+}
+.modal-close:hover,
+.modal-close:active {
+  color: blue;
 }
 
 /* ===== MEDIA QUERIES=====*/
@@ -579,7 +588,7 @@ img {
     padding-top: 2rem;
   }
   .contact__form {
-    width: 360px;
+    width: 500px;
     padding-top: 2rem;
   }
   .contact__container {

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
                     <span class="skills__name">Adaptability and Resiliency</span>
                     <span class="skills__percentage">85%</span>
                     <div class="skills__bar skills__adaptability"></div>
+                    <p class="skills__desc">Quickly adjust to change while remaining focused and optimistic.</p>
                 </div>
                 <div class="skills__data">
                     <span class="skills__name">Collaboration and Teamwork</span>
@@ -239,88 +240,64 @@
             <div id="modal-exec" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">Executive Member, Health Studies Student Association</h3>
-                    <p class="experience__description">Planned events and initiatives promoting the health studies community.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">Leading this group taught me how to organize teams and communicate effectively across campus.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
             <div id="modal-shadow" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">Job Shadow at SOAR Family Chiropractic</h3>
-                    <p class="experience__description">Observed professional chiropractic practice and patient care.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">Witnessing real client interactions deepened my understanding of professionalism in health settings.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
             <div id="modal-hs102" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">HS102: An Intro to Public Health</h3>
-                    <p class="experience__description">Students invent a new disease and, using their knowledge from the course, provide an in-depth profile of this disease, including its impact on the population, relevant disease characteristics, modes of transmission, basic epidemiology and possible public health interventions used to curb this disease.</p>
-                    <h3 class="section-title" style="text-align:left;">Developed Competencies</h3>
-                    <p class="experience__description">Creativity and Innovation, Communication, Digital Literacy, Problem Solving, Functional Knowledge</p>
-                    <h3 class="section-title" style="text-align:left;">Type of Experience</h3>
-                    <p class="experience__description">In-course Simulated Experience</p>
-                    <h3 class="section-title" style="text-align:left;">What is this experience?</h3>
-                    <p class="experience__description">Simulated-workplace projects and experiences completed as a required component of a course or programme of study.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">This project helped me understand how new public health challenges are approached and deepened my appreciation for clear communication when proposing interventions.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
             <div id="modal-ch111" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">CH111: Fundamentals of Chemistry II</h3>
-                    <p class="experience__description">Hands-on laboratory techniques reinforcing core chemistry concepts.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">Advanced experiments in this course strengthened my analytical thinking and precision in the lab.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
             <div id="modal-bi111" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">BI111: Biological Diversity Evolution</h3>
-                    <p class="experience__description">Examined biodiversity through experiments and group projects.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">Working with classmates on field studies improved my collaboration and observation skills.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
             <div id="modal-preschool" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">Preschool Classroom Assistant at A Child's Paradise</h3>
-                    <p class="experience__description">Assisted teachers and supported early childhood learning activities.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">Helping young children taught me patience and the importance of clear instructions.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
             <div id="modal-lead" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">LEAD Participant, LEAD @ Laurier Summer Retreat</h3>
-                    <p class="experience__description">Developed leadership skills through workshops and team challenges.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">The retreat pushed me out of my comfort zone and improved my confidence when working with new peers.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
             <div id="modal-ch110" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">CH110: Fundamentals of Chemistry I</h3>
-                    <p class="experience__description">Introduced basic chemistry methods and safety practices.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">Starting in this lab built the foundation for my later scientific work.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
             <div id="modal-bi110" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
-                    <h3 class="section-title" style="text-align:left;">BI110: Unifying Life Processes</h3>
-                    <p class="experience__description">Explored fundamental biological processes using modern lab tools.</p>
-                    <h3 class="section-title" style="text-align:left;">Arsh's Reflection</h3>
-                    <p class="experience__description">These introductory labs enhanced my understanding of cell biology and experimental design.</p>
+                    <h3 class="section-title" style="text-align:center;">Reflection</h3>
+                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- simplify all experience modals to only show a centered reflection
- describe adaptability competency in the skills section
- enlarge contact form and add hover color for modal close buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864464480b88328b1fb0132582ce4e4