### PR TITLE
Refine home and experience content

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -316,6 +316,11 @@ img {
   flex-direction: column;
   text-align: center;
 }
+.skills__row .skills__header {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
 .skills__desc {
   font-size: var(--smaller-font-size);
   margin-top: 0.5rem;

--- a/index.html
+++ b/index.html
@@ -31,8 +31,7 @@
     <main class="l-main">
         <section class="home bd-grid" id="home">
             <div class="home__data">
-                <h1 class="home__title">Hi,<br>I'm <span class="home__title-color">Arshdeep</span><br>an underneath Health Science<br>student</h1>
-                <p class="home__text">I ensure that the font size, colour scheme and pages are quite interactive and well managed.</p>
+                <h1 class="home__title">Hi, I'm <span class="home__title-color">Arshdeep Kaur</span>, a health science student.</h1>
                 <a href="#contact" class="button">Contact</a>
             </div>
             <div class="home__social">
@@ -69,9 +68,11 @@
         <section class="skills section" id="skills">
             <h2 class="section-title">Competencies</h2>
             <div class="skills__container bd-grid">
-                <div class="skills__data">
-                    <span class="skills__name">Adaptability and Resiliency</span>
-                    <span class="skills__percentage">85%</span>
+                <div class="skills__data skills__row">
+                    <div class="skills__header">
+                        <span class="skills__name">Adaptability and Resiliency</span>
+                        <span class="skills__percentage">85%</span>
+                    </div>
                     <div class="skills__bar skills__adaptability"></div>
                     <p class="skills__desc">Quickly adjust to change while remaining focused and optimistic.</p>
                 </div>
@@ -143,6 +144,7 @@
                     </div>
                     <div class="experience__body">
                         <h3 class="experience__course">Executive Member, Health Studies Student Association</h3>
+                        <p class="experience__description">Coordinated events and promoted student health initiatives on campus.</p>
                         
                         <a href="#" class="button experience__button" data-target="modal-exec">View</a>
                     </div>
@@ -241,63 +243,63 @@
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
             <div id="modal-shadow" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
             <div id="modal-hs102" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
             <div id="modal-ch111" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
             <div id="modal-bi111" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
             <div id="modal-preschool" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
             <div id="modal-lead" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
             <div id="modal-ch110" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
             <div id="modal-bi110" class="modal">
                 <div class="modal-content">
                     <span class="modal-close">&times;</span>
                     <h3 class="section-title" style="text-align:center;">Reflection</h3>
-                    <p class="experience__description">During this experience I was able to step outside my comfort zone and engage in hands-on learning. It challenged me to work collaboratively with new peers, explore unfamiliar concepts, and adapt to unexpected obstacles. Through these challenges I grew more confident in my ability to communicate effectively and maintain a positive outlook even when tasks became complex. This reflection reminds me to keep learning and stay resilient in new situations.</p>
+                        <p class="experience__description">This experience pushed me to adapt quickly and collaborate with unfamiliar peers. I learned to communicate in challenging situations and remain positive despite unexpected hurdles. Working through obstacles strengthened my confidence and showed me the value of continual learning and resilience in new environments. Through this process, I also gained insight into new perspectives.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- update home section headline
- add custom layout for first competency
- provide description for executive member experience
- shorten modal reflections

## Testing
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68644878e37c832887b90a5891d75cfc